### PR TITLE
clarification on Location service

### DIFF
--- a/_posts/2016-04-25-issue-3.md
+++ b/_posts/2016-04-25-issue-3.md
@@ -12,13 +12,14 @@ date:   2016-04-25
 
 - [angular/angular/pull/8173](https://github.com/angular/angular/pull/8173)
 
-### 2. Location service has been moved into platform/browser
+### 2. Location service has been moved into platform/common
 
-`Location` provides APIs to access information about the current browser location. So far, this service was part of the router module. However, since there are cases where we need access to this information, even though there's no router in that application, this service has been moved to `platform/browser`. Thank you [Nathan Walker](https://twitter.com/wwwalkerrun) for making this a thing!
+`Location` provides APIs to access information about the current browser location. This service is actually platform agnostic as it can be used in *native* mobile apps, not just the browser. So far, this service was part of the router module. However, since there are cases where we need access to this information, even though there may be no router in that application, this service has been moved to `platform/common`. Thank you [Nathan Walker](https://twitter.com/wwwalkerrun) for making this a thing!
 
 #### Related pull requests and issues
 
 - [angular/angular/pull/4943](https://github.com/angular/angular/issues/4943)
+- [angular/angular/pull/7962](https://github.com/angular/angular/pull/7962)
 
 ### 3. Angular Material 2 Alpha 3 has been released!
 


### PR DESCRIPTION
* Clarification that it was actually moved to `platform/common` and added a line to help support why `common`.
* Added link to PR with more details/discussion around why `platform/common` instead of `platform/browser`

Thanks!