### PR TITLE
fix(2016-06-20-issue-8): fix typo

### DIFF
--- a/_posts/2016-06-20-issue-8.md
+++ b/_posts/2016-06-20-issue-8.md
@@ -10,7 +10,7 @@ After several weeks of hard work, the Angular team released a new release candid
 
 ### 2. Radio Buttons can now share `FormControl` instance
 
-Using Radio Buttons became a whole lot easier thanks to the great [@karaforthewin](http://twitter.com/karaforthewin). It's no longer needed to create the `RadioButtonSate` imperatively to manage radio buttons. All we need is:
+Using Radio Buttons became a whole lot easier thanks to the great [@karaforthewin](http://twitter.com/karaforthewin). It's no longer needed to create the `RadioButtonState` imperatively to manage radio buttons. All we need is:
 
 {% highlight html %}
 <form #f="ngForm">


### PR DESCRIPTION
Although `sate` is a great word in the context of fish and chicken, I think it should be `state` ;-)